### PR TITLE
Remove /hadiths "Get a list of Hadiths" from API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ __pycache__
 .vscode/
 .coverage
 venv
+.venv/
 
-.env.local
+.env.*

--- a/spec.v1.yml
+++ b/spec.v1.yml
@@ -227,48 +227,6 @@ paths:
           required: true
           schema:
             type: string
-  /hadiths:
-    get:
-      summary: Get a list of hadiths
-      description: ""
-      responses:
-        "200":
-          description: Paginated list of hadiths
-          content:
-            application/json:
-              schema:
-                type: object
-                allOf:
-                  - properties:
-                      data:
-                        type: array
-                        items:
-                          $ref: "#/components/schemas/Hadith"
-                  - $ref: "#/components/schemas/PaginatedResponse"
-      parameters:
-        - in: query
-          name: collection
-          description: Name of the collection
-          schema:
-            type: string
-        - in: query
-          name: bookNumber
-          description: Number of the book
-          schema:
-            type: string
-        - in: query
-          name: chapterId
-          description: ID of the chapter
-          schema:
-            type: number
-            format: float
-        - in: query
-          name: hadithNumber
-          description: Hadith number
-          schema:
-            type: string
-        - $ref: "#/components/parameters/limit"
-        - $ref: "#/components/parameters/page"
   "/hadiths/{urn}":
     get:
       summary: Get a hadith by its URN


### PR DESCRIPTION
The following endpoint is listed in the API docs but is not implemented in flask: [/hadiths](https://sunnah.stoplight.io/docs/api/hp9hzrfn7wia9-get-a-list-of-hadiths)

The query parameters specify a collection, book, chapter, and hadith number but the description says that it will return a list of hadiths. This does not make sense because we are specifying a specific hadith number. We already have endpoints that support retrieving a single hadith and also endpoints for returning a paginated list of hadiths in a book. 

I also added .venv to gitignore because that is how I am managing my python dependencies.