### PR TITLE
Apply flake8 formatting to all python files

### DIFF
--- a/text_transform.py
+++ b/text_transform.py
@@ -92,6 +92,7 @@ def cleanup_chapter_title(text):
     text = text.strip()
     return text
 
+
 def cleanup_en_chapter_title(text):
     if not text:
         return text


### PR DESCRIPTION
`Surround top-level function and class definitions with two blank lines.`

[Pep8 docs](https://peps.python.org/pep-0008/#blank-lines)