### PR TITLE
Add platform attribute to docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3'
 services:
   db:
     image: mysql:5.7.22
+    platform: linux/x86_64
     command: --default-authentication-plugin=mysql_native_password
     volumes:
       - ./db:/docker-entrypoint-initdb.d/:ro
@@ -12,6 +13,7 @@ services:
     depends_on:
       - "db"
     build: .
+    platform: linux/x86_64
     command: flask run --host=0.0.0.0
     volumes:
       - .:/code


### PR DESCRIPTION
Add platform attribute to docker compose file so that it works on apple silicon see [here](https://stackoverflow.com/questions/65456814/docker-apple-silicon-m1-preview-mysql-no-matching-manifest-for-linux-arm64-v8).